### PR TITLE
config: fix cache path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
-            - .node_modules
+            - ./node_modules
       - run:
           name: test
           command: npm test


### PR DESCRIPTION
The path to cache was missing a slash, meaning it was looking for a "dot folder" instead of a relative path which ultimately led to an empty cache.

Seeing how users will likely copy paste from this config it seems important [to me] that it is correct and implements best practices.

Fixes: #1.