### PR TITLE
Add workflow declaration to config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,11 @@
 version: 2.1
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build
+
 jobs:
   build:
     working_directory: ~/mern-starter


### PR DESCRIPTION
There wasn't a workflow declaration before, so the workflow was assumed, which might be confusing for people wanting to use this project as an example.

Solution: Added a workflow declaration.